### PR TITLE
pcre and pcre2: fix instruction cache flushing on ppc/ppc64/ppc64le.

### DIFF
--- a/srcpkgs/pcre/patches/ppc-icache-flush.patch
+++ b/srcpkgs/pcre/patches/ppc-icache-flush.patch
@@ -1,0 +1,102 @@
+GCC's version of __builtin___clear_cache() is a no-op on PowerPC.
+Change to use an improved version of the existing ppc_cache_flush().
+
+--- a/sljit/sljitConfigInternal.h	2022-02-12 21:42:26.812059103 -0800
++++ b/sljit/sljitConfigInternal.h	2022-02-12 21:42:57.508834803 -0800
+@@ -284,7 +284,8 @@
+ /****************************/
+ 
+ #if (!defined SLJIT_CACHE_FLUSH && defined __has_builtin)
+-#if __has_builtin(__builtin___clear_cache)
++#if __has_builtin(__builtin___clear_cache) && \
++	!(defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC)
+ 
+ #define SLJIT_CACHE_FLUSH(from, to) \
+ 	__builtin___clear_cache((char*)from, (char*)to)
+--- a/sljit/sljitNativePPC_common.c	2022-02-12 21:42:26.816059204 -0800
++++ b/sljit/sljitNativePPC_common.c	2022-02-12 21:42:57.512834904 -0800
+@@ -46,6 +46,39 @@
+ #define SLJIT_PASS_ENTRY_ADDR_TO_CALL 1
+ #endif
+ 
++#ifdef __linux__
++#include <sys/auxv.h>
++
++/* Return the instruction cache line size, in bytes. */
++static SLJIT_INLINE sljit_u32 get_icache_line_size()
++{
++	static sljit_u32 icache_line_size = 0;
++	if (SLJIT_UNLIKELY(!icache_line_size)) {
++		icache_line_size = (sljit_u32) getauxval(AT_ICACHEBSIZE);
++		SLJIT_ASSERT(icache_line_size != 0);
++	}
++	return icache_line_size;
++}
++
++/* Cache and return the first hardware capabilities word. */
++static SLJIT_INLINE unsigned long get_hwcap()
++{
++	static unsigned long hwcap = 0;
++	if (SLJIT_UNLIKELY(!hwcap)) {
++		hwcap = getauxval(AT_HWCAP);
++		SLJIT_ASSERT(hwcap != 0);
++	}
++	return hwcap;
++}
++
++/* Return non-zero if this CPU has the icache snoop feature. */
++static SLJIT_INLINE unsigned long has_feature_icache_snoop()
++{
++	return (get_hwcap() & PPC_FEATURE_ICACHE_SNOOP);
++}
++
++#endif  /* __linux__ */
++
+ #if (defined SLJIT_CACHE_FLUSH_OWN_IMPL && SLJIT_CACHE_FLUSH_OWN_IMPL)
+ 
+ static void ppc_cache_flush(sljit_ins *from, sljit_ins *to)
+@@ -68,14 +101,40 @@
+ #	error "Cache flush is not implemented for PowerPC/POWER common mode."
+ #	else
+ 	/* Cache flush for PowerPC architecture. */
+-	while (from < to) {
++	/* For POWER5 and up with icache snooping, only one icbi in the range
++ 	 * is required. The sync flushes the store queue, and the icbi/isync
++	 * kills the local prefetch.
++	 */
++	if (has_feature_icache_snoop()) {
+ 		__asm__ volatile (
+-			"dcbf 0, %0\n"
+ 			"sync\n"
+ 			"icbi 0, %0\n"
+-			: : "r"(from)
++			"isync\n"
++			: : "r"(from) : "memory"
++		);
++		return;
++	}
++
++	sljit_u32 cache_line_bytes = get_icache_line_size();
++	sljit_u32 cache_line_words = cache_line_bytes / sizeof(sljit_ins);
++	uintptr_t cache_line_mask = ~(uintptr_t)(cache_line_bytes - 1);
++
++	/* Round down to start of cache line to simplify the end condition. */
++	sljit_ins* start = (sljit_ins*)((uintptr_t)(from) & cache_line_mask);
++
++	for (from = start; from < to; from += cache_line_words) {
++		__asm__ volatile (
++			"dcbf 0, %0"
++			: : "r"(from) : "memory"
++		);
++	}
++	__asm__ volatile ( "sync" );
++
++	for (from = start; from < to; from += cache_line_words) {
++		__asm__ volatile (
++			"icbi 0, %0"
++			: : "r"(from) : "memory"
+ 		);
+-		from++;
+ 	}
+ 	__asm__ volatile ( "isync" );
+ #	endif

--- a/srcpkgs/pcre2/patches/ppc-icache-flush.patch
+++ b/srcpkgs/pcre2/patches/ppc-icache-flush.patch
@@ -1,0 +1,102 @@
+GCC's version of __builtin___clear_cache() is a no-op on PowerPC.
+Change to use an improved version of the existing ppc_cache_flush().
+
+--- a/src/sljit/sljitConfigInternal.h	2021-08-20 09:51:28.000000000 -0700
++++ b/src/sljit/sljitConfigInternal.h	2022-02-11 20:56:43.159092563 -0800
+@@ -320,7 +320,8 @@
+ /****************************/
+ 
+ #if (!defined SLJIT_CACHE_FLUSH && defined __has_builtin)
+-#if __has_builtin(__builtin___clear_cache)
++#if __has_builtin(__builtin___clear_cache) && \
++	!(defined SLJIT_CONFIG_PPC && SLJIT_CONFIG_PPC)
+ 
+ #define SLJIT_CACHE_FLUSH(from, to) \
+ 	__builtin___clear_cache((char*)(from), (char*)(to))
+--- a/src/sljit/sljitNativePPC_common.c	2022-02-12 20:46:28.383224561 -0800
++++ b/src/sljit/sljitNativePPC_common.c	2022-02-12 20:48:22.210099029 -0800
+@@ -46,6 +46,39 @@
+ #define SLJIT_PASS_ENTRY_ADDR_TO_CALL 1
+ #endif
+ 
++#ifdef __linux__
++#include <sys/auxv.h>
++
++/* Return the instruction cache line size, in bytes. */
++static SLJIT_INLINE sljit_u32 get_icache_line_size()
++{
++	static sljit_u32 icache_line_size = 0;
++	if (SLJIT_UNLIKELY(!icache_line_size)) {
++		icache_line_size = (sljit_u32) getauxval(AT_ICACHEBSIZE);
++		SLJIT_ASSERT(icache_line_size != 0);
++	}
++	return icache_line_size;
++}
++
++/* Cache and return the first hardware capabilities word. */
++static SLJIT_INLINE unsigned long get_hwcap()
++{
++	static unsigned long hwcap = 0;
++	if (SLJIT_UNLIKELY(!hwcap)) {
++		hwcap = getauxval(AT_HWCAP);
++		SLJIT_ASSERT(hwcap != 0);
++	}
++	return hwcap;
++}
++
++/* Return non-zero if this CPU has the icache snoop feature. */
++static SLJIT_INLINE unsigned long has_feature_icache_snoop()
++{
++	return (get_hwcap() & PPC_FEATURE_ICACHE_SNOOP);
++}
++
++#endif  /* __linux__ */
++
+ #if (defined SLJIT_CACHE_FLUSH_OWN_IMPL && SLJIT_CACHE_FLUSH_OWN_IMPL)
+ 
+ static void ppc_cache_flush(sljit_ins *from, sljit_ins *to)
+@@ -68,14 +101,40 @@
+ #	error "Cache flush is not implemented for PowerPC/POWER common mode."
+ #	else
+ 	/* Cache flush for PowerPC architecture. */
+-	while (from < to) {
++	/* For POWER5 and up with icache snooping, only one icbi in the range
++ 	 * is required. The sync flushes the store queue, and the icbi/isync
++	 * kills the local prefetch.
++	 */
++	if (has_feature_icache_snoop()) {
+ 		__asm__ volatile (
+-			"dcbf 0, %0\n"
+ 			"sync\n"
+ 			"icbi 0, %0\n"
+-			: : "r"(from)
++			"isync\n"
++			: : "r"(from) : "memory"
++		);
++		return;
++	}
++
++	sljit_u32 cache_line_bytes = get_icache_line_size();
++	sljit_u32 cache_line_words = cache_line_bytes / sizeof(sljit_ins);
++	uintptr_t cache_line_mask = ~(uintptr_t)(cache_line_bytes - 1);
++
++	/* Round down to start of cache line to simplify the end condition. */
++	sljit_ins* start = (sljit_ins*)((uintptr_t)(from) & cache_line_mask);
++
++	for (from = start; from < to; from += cache_line_words) {
++		__asm__ volatile (
++			"dcbf 0, %0"
++			: : "r"(from) : "memory"
++		);
++	}
++	__asm__ volatile ( "sync" );
++
++	for (from = start; from < to; from += cache_line_words) {
++		__asm__ volatile (
++			"icbi 0, %0"
++			: : "r"(from) : "memory"
+ 		);
+-		from++;
+ 	}
+ 	__asm__ volatile ( "isync" );
+ #	endif


### PR DESCRIPTION
GCC's version of __builtin___clear_cache() is a no-op on PowerPC,
which causes the unit tests to fail on at least PowerPC 970 and 7447A,
and is technically incorrect. Change the code to use an improved version
of the existing ppc_cache_flush() function that wasn't being called.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
- I tested on a Quad G5 2.5 GHz and a Mac mini G4. Both failed "make check" without the patch, and both succeeded with the patch.

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architectures, ppc64-glibc and ppc-glibc.
- This patch needs to be tested on some POWER5 or newer systems, just to make sure the "instruction cache snoop" fast path also works.